### PR TITLE
FT_New_Face path string fix

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -659,7 +659,7 @@ extern "C" {
     pub fn FT_Init_FreeType(alibrary: *mut FT_Library) -> FT_Error;
     pub fn FT_Done_FreeType(library: FT_Library) -> FT_Error;
     pub fn FT_Done_Library(library: FT_Library) -> FT_Error;
-    pub fn FT_New_Face(library: FT_Library, filepathname: *const u8, face_index: FT_Long, aface: *mut FT_Face) -> FT_Error;
+    pub fn FT_New_Face(library: FT_Library, filepathname: *const i8, face_index: FT_Long, aface: *mut FT_Face) -> FT_Error;
     pub fn FT_New_Memory_Face(library: FT_Library, file_base: *const FT_Byte, file_size: FT_Long, face_index: FT_Long, aface: *mut FT_Face) -> FT_Error;
     pub fn FT_Open_Face(library: FT_Library, args: *const FT_Open_Args, face_index: FT_Long, aface: *mut FT_Face) -> FT_Error;
     pub fn FT_Attach_File(face: FT_Face, filepathname: *const c_char) -> FT_Error;

--- a/src/library.rs
+++ b/src/library.rs
@@ -29,7 +29,10 @@ impl Library {
     pub fn new_face(&self, filepathname: &str, face_index: ffi::FT_Long) -> FtResult<Face> {
         unsafe {
             let mut face = std::ptr::mut_null();
-            let err = ffi::FT_New_Face(self.raw, filepathname.as_slice().as_ptr(), face_index, &mut face);
+
+            let path_str = filepathname.to_c_str();
+
+            let err = ffi::FT_New_Face(self.raw, path_str.as_ptr(), face_index, &mut face);
             if err == ffi::FT_Err_Ok {
                 Ok(Face::from_raw(face))
             } else {


### PR DESCRIPTION
Sometimes fonts couldn't be opened. Previously FT_New_Face received an u8 slice, which was not null terminated. Passing a null terminated path string fixes this.

https://github.com/PistonDevelopers/freetype-rs/issues/31 seems to be related to this.
