### PR TITLE
Make the safe interface a little safer.

### DIFF
--- a/examples/single_glyph/single_glyph.rs
+++ b/examples/single_glyph/single_glyph.rs
@@ -1,12 +1,11 @@
 
-extern crate debug;
 extern crate freetype;
 
 use freetype as ft;
 use freetype::ffi;
 
-static WIDTH: ffi::FT_Int = 32;
-static HEIGHT: ffi::FT_Int = 24;
+const WIDTH: ffi::FT_Int = 32;
+const HEIGHT: ffi::FT_Int = 24;
 
 fn draw_bitmap(bitmap: &ffi::FT_Bitmap, x: ffi::FT_Int, y: ffi::FT_Int) -> [[u8, ..WIDTH as uint], ..HEIGHT as uint] {
     let mut image: [[u8, ..WIDTH as uint], ..HEIGHT as uint] = [
@@ -70,9 +69,9 @@ fn main() {
     let ref text = args[2];
 
     let library = ft::Library::init().unwrap();
-    let face = library.new_face(filename.as_slice(), 0).unwrap();
+    let mut face = library.new_face(filename.as_slice(), 0).unwrap();
     face.set_char_size(40 * 64, 0, 50, 0).unwrap();
-    face.load_char(text.as_bytes()[0] as u64, ft::face::Render).unwrap();
+    face.load_char(text.as_bytes()[0] as u64, ft::face::RENDER).unwrap();
 
     let slot = face.glyph().raw();
     let image = draw_bitmap(&slot.bitmap, slot.bitmap_left, HEIGHT - slot.bitmap_top);

--- a/examples/single_glyph_ffi/single_glyph_ffi.rs
+++ b/examples/single_glyph_ffi/single_glyph_ffi.rs
@@ -1,11 +1,10 @@
 
-extern crate debug;
 extern crate freetype;
 
 use freetype::ffi;
 
-static WIDTH: ffi::FT_Int = 32;
-static HEIGHT: ffi::FT_Int = 24;
+const WIDTH: ffi::FT_Int = 32;
+const HEIGHT: ffi::FT_Int = 24;
 
 fn draw_bitmap(bitmap: &ffi::FT_Bitmap, x: ffi::FT_Int, y: ffi::FT_Int) -> [[u8, ..WIDTH as uint], ..HEIGHT as uint] {
     let mut image: [[u8, ..WIDTH as uint], ..HEIGHT as uint] = [
@@ -69,14 +68,14 @@ fn main() {
         let filename = &args[1];
         let text = &args[2];
 
-        let mut library: ffi::FT_Library = std::ptr::mut_null();
+        let mut library: ffi::FT_Library = std::ptr::null_mut();
         let error = ffi::FT_Init_FreeType(&mut library);
         if error != ffi::FT_Err_Ok {
             println!("Could not initialize freetype.");
             return;
         }
 
-        let mut face: ffi::FT_Face = std::ptr::mut_null();
+        let mut face: ffi::FT_Face = std::ptr::null_mut();
         let error = ffi::FT_New_Face(library, filename.to_c_str().as_ptr(), 0, &mut face);
         if error != ffi::FT_Err_Ok {
             println!("Could not load font '{}'. Error Code: {}", filename, error);

--- a/src/face.rs
+++ b/src/face.rs
@@ -60,7 +60,7 @@ impl Face {
         }
     }
 
-    pub fn attach_file(&self, filepathname: &str) -> FtResult<()> {
+    pub fn attach_file(&mut self, filepathname: &str) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Attach_File(self.raw, filepathname.as_slice().as_ptr() as *const i8);
             if err == ffi::FT_Err_Ok {
@@ -71,7 +71,7 @@ impl Face {
         }
     }
 
-    pub fn reference(&self) -> FtResult<()> {
+    pub fn reference(&mut self) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Reference_Face(self.raw);
             if err == ffi::FT_Err_Ok {
@@ -82,7 +82,7 @@ impl Face {
         }
     }
 
-    pub fn set_char_size(&self, char_width: ffi::FT_F26Dot6, char_height: ffi::FT_F26Dot6, horz_resolution: ffi::FT_UInt, vert_resolution: ffi::FT_UInt) -> FtResult<()> {
+    pub fn set_char_size(&mut self, char_width: ffi::FT_F26Dot6, char_height: ffi::FT_F26Dot6, horz_resolution: ffi::FT_UInt, vert_resolution: ffi::FT_UInt) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Set_Char_Size(self.raw, char_width, char_height, horz_resolution, vert_resolution);
             if err == ffi::FT_Err_Ok {
@@ -93,7 +93,7 @@ impl Face {
         }
     }
 
-    pub fn set_pixel_sizes(&self, pixel_width: ffi::FT_UInt, pixel_height: ffi::FT_UInt) -> FtResult<()> {
+    pub fn set_pixel_sizes(&mut self, pixel_width: ffi::FT_UInt, pixel_height: ffi::FT_UInt) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Set_Pixel_Sizes(self.raw, pixel_width, pixel_height);
             if err == ffi::FT_Err_Ok {
@@ -104,7 +104,7 @@ impl Face {
         }
     }
 
-    pub fn load_glyph(&self, glyph_index: ffi::FT_UInt, load_flags: LoadFlag) -> FtResult<()> {
+    pub fn load_glyph(&mut self, glyph_index: ffi::FT_UInt, load_flags: LoadFlag) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Load_Glyph(self.raw, glyph_index, load_flags.bits);
             if err == ffi::FT_Err_Ok {
@@ -115,7 +115,7 @@ impl Face {
         }
     }
 
-    pub fn load_char(&self, char_code: ffi::FT_ULong, load_flags: LoadFlag) -> FtResult<()> {
+    pub fn load_char(&mut self, char_code: ffi::FT_ULong, load_flags: LoadFlag) -> FtResult<()> {
         unsafe {
             let err = ffi::FT_Load_Char(self.raw, char_code, load_flags.bits);
             if err == ffi::FT_Err_Ok {
@@ -126,7 +126,7 @@ impl Face {
         }
     }
 
-    pub fn set_transform(&self, matrix: &Matrix, delta: &Vector) {
+    pub fn set_transform(&mut self, matrix: &Matrix, delta: &Vector) {
         unsafe {
             ffi::FT_Set_Transform(self.raw, matrix, delta);
         }


### PR DESCRIPTION
Since FT_Load_Char destructively updates the Face's glyph slot,
we need to ensure that no one is holding a reference to that
slot when FT_Load_Char is called. In particular, that means we
shouldn't ever return an actual reference to the glyph slot.

To be honest, I'm not sure what's an idiomatic way to do something
like this (I'm new to rust), and I'm not even comfortable enough with
the borrow checker to be sure that this is correct...
