### PR TITLE
Upgrade to latest Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Coeuvre <coeuvre@gmail.com>"]
 
 [lib]
 
-name = "freetype_rs"
+name = "freetype"
 path = "src/lib.rs"

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -16,7 +16,10 @@ impl Bitmap {
     #[inline(always)]
     pub fn buffer(&self) -> &[u8] {
         unsafe {
-            std::slice::raw::buf_as_slice((*self.raw).buffer, (self.width() * self.rows()) as uint, |buf: &[u8]| std::mem::transmute(buf))
+            std::slice::from_raw_buf(
+                &(*self.raw).buffer, 
+                (self.width() * self.rows()) as uint, 
+            )
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 
 #![crate_type = "lib"]
-#![crate_name="freetype_rs"]
-#![desc = "Rust bindings for FreeType"]
-#![license = "MIT"]
 
 extern crate libc;
 


### PR DESCRIPTION
- Fixed crate name
- Removed unused attributes
- Replaced `buf_as_slice` with `from_raw_buf`
