### PR TITLE
Use a Cargo build script to link to freetype2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ watch.sh
 /examples/**/target
 
 Cargo.lock
+/freetype-sys/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ authors = ["Coeuvre <coeuvre@gmail.com>"]
 
 name = "freetype"
 path = "src/lib.rs"
+
+[dependencies.freetype-sys]
+path = "freetype-sys"

--- a/freetype-sys/Cargo.toml
+++ b/freetype-sys/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+
+name = "freetype-sys"
+version = "0.0.1"
+authors = ["Coeuvre <coeuvre@gmail.com>"]
+build = "build.rs"
+
+[build-dependencies]
+pkg-config = "*"

--- a/freetype-sys/build.rs
+++ b/freetype-sys/build.rs
@@ -1,0 +1,14 @@
+extern crate "pkg-config" as pkg_config;
+
+fn main() {
+    match pkg_config::find_library("freetype2") {
+        Ok(_) => return,
+        Err(_) => {
+            if cfg!(windows) {
+                println!("cargo:rustc-flags=-l freetype-6:dylib");
+            } else {
+                println!("cargo:rustc-flags=-l freetype:dylib");
+            }
+        }
+    }
+}

--- a/freetype-sys/src/lib.rs
+++ b/freetype-sys/src/lib.rs
@@ -3,6 +3,8 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
+extern crate libc;
+
 use libc::{
     c_char,
     c_void,
@@ -788,14 +790,9 @@ pub fn FT_HAS_COLOR(face: FT_Face) -> bool {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-#[link(name = "freetype")]
 extern {
     pub fn FT_Get_Sfnt_Table(face: FT_Face, tag: FT_Sfnt_Tag) -> *mut c_void;
 }
-
-#[cfg(windows)]
-#[link(name = "freetype-6")]
-extern {}
 
 extern "C" {
     pub fn FT_Init_FreeType(alibrary: *mut FT_Library) -> FT_Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![crate_type = "lib"]
 
 extern crate libc;
+extern crate "freetype-sys" as freetype_sys;
 
 pub use bitmap::Bitmap;
 pub use bitmap_glyph::BitmapGlyph;
@@ -12,12 +13,12 @@ pub use glyph_slot::GlyphSlot;
 pub use library::Library;
 pub use outline::Outline;
 pub use render_mode::RenderMode;
+pub use freetype_sys as ffi;
 
 pub mod bitmap;
 pub mod bitmap_glyph;
 pub mod error;
 pub mod face;
-pub mod ffi;
 pub mod glyph;
 pub mod glyph_slot;
 pub mod library;


### PR DESCRIPTION
Extracts `ffi.rs` into `freetype-sys/src/lib.rs` and adds a Cargo build script.

Shouldn't break any code since I reexport `ffi` in the main library.
