### PR TITLE
Hacks to compile with latest rust nightly (522d09dfe 2015-02-19, built 2015-02-20)

### DIFF
--- a/src/outline.rs
+++ b/src/outline.rs
@@ -1,10 +1,11 @@
 use ffi;
-use std::{mem, raw};
+use std::{marker, mem, raw};
 use libc::{c_short, c_char};
 
 pub use ffi::FT_Vector as Vector;
 
-pub enum Curve<'a> {
+#[derive(Copy)]
+pub enum Curve {
     Line(Vector),
     Bezier2(Vector, Vector),
     Bezier3(Vector, Vector, Vector),
@@ -44,6 +45,7 @@ pub struct CurveIterator<'a> {
     start_tag: *const c_char,
     idx: isize,
     length: isize,
+    marker: marker::PhantomData<&'a ()>,
 }
 
 impl<'a> CurveIterator<'a> {
@@ -55,6 +57,7 @@ impl<'a> CurveIterator<'a> {
             start_tag: outline.tags.offset(start_idx),
             idx: 0,
             length: end_idx - start_idx + 1,
+            marker: marker::PhantomData,
         }
     }
 
@@ -82,8 +85,8 @@ impl<'a> CurveIterator<'a> {
 }
 
 impl<'a> Iterator for CurveIterator<'a> {
-	type Item = Curve<'a>;
-    fn next(&mut self) -> Option<Curve<'a>> {
+	type Item = Curve;
+    fn next(&mut self) -> Option<Curve> {
         if self.idx >= self.length {
             None
         } else {
@@ -155,5 +158,3 @@ impl<'a> Iterator for ContourIterator<'a> {
         }
     }
 }
-
-


### PR DESCRIPTION
**Massive disclaimer:** I don't know whether this PR is correct; as I'm still very new to Rust, it's mainly derived from banging away until the compile errors disappear. It very much requires review by somebody who knows what they're doing.

Latest rust nightly gives a bunch of compile errors:

```
$ rustc --version
rustc 1.0.0-nightly (522d09dfe 2015-02-19) (built 2015-02-20)
$ cargo build
   Compiling freetype-rs v0.0.6 (file:///home/caspar/src/rs/freetype-rs)
src/outline.rs:7:16: 7:18 error: parameter `'a` is never used
src/outline.rs:7 pub enum Curve<'a> {
                                ^~
src/outline.rs:7:16: 7:18 help: consider removing `'a` or using a marker such as `core::marker::PhantomData`
src/outline.rs:7 pub enum Curve<'a> {
                                ^~
src/outline.rs:42:26: 42:28 error: parameter `'a` is never used
src/outline.rs:42 pub struct CurveIterator<'a> {
                                           ^~
src/outline.rs:42:26: 42:28 help: consider removing `'a` or using a marker such as `core::marker::PhantomData`
src/outline.rs:42 pub struct CurveIterator<'a> {
                                           ^~
error: aborting due to 2 previous errors
Could not compile `freetype-rs`.
```

So to fix this I:
- did what the help messages suggested and removed the lifetime parameter for Curve.
- added a derived `Copy` impl for `Curve`, because `#![deny(missing_copy_implementations)]` complains if there isn't one
- also tried removing the lifetime parameter for `CurveIterator`, but it seemed like this was needed by `ContourIterator`'s `from_raw`? So instead I added a `PhantomData` parameterised on Unit to the struct instead, which as far as I can tell just stops the compiler from complaining about the unused lifetime param?

Now it builds, but `cargo test` still seems to be failing due to freetype-rs being dragged in from the PistonDevelopers repo even though I added my clone of freetype-rs to the cargo paths overrride (this feels like a cargo bug?). The piston getting started example works using this (which was my main goal), but that doesn't include any text rendering so I guess it's not particularly indicative of success for this PR.