### PR TITLE
Limits the life on the buffer for new_memory_face.

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -54,7 +54,7 @@ impl Library {
         }
     }
 
-    pub fn new_face<P: AsRef<OsStr>>(&self, filepath: P, face_index: isize) -> FtResult<Face> {
+    pub fn new_face<P: AsRef<OsStr>>(&self, filepath: P, face_index: isize) -> FtResult<Face<'static>> {
         unsafe {
             let mut face = null_mut();
 
@@ -69,7 +69,7 @@ impl Library {
         }
     }
 
-    pub fn new_memory_face(&self, buffer: &[u8], face_index: isize) -> FtResult<Face> {
+    pub fn new_memory_face<'a>(&self, buffer: &'a[u8], face_index: isize) -> FtResult<Face<'a>> {
         unsafe {
             let mut face = null_mut();
             let err = ffi::FT_New_Memory_Face(self.raw, buffer.as_ptr(),


### PR DESCRIPTION
In the documentation for Freetype for `new_memory_face`:

```
Note that you must not deallocate the memory before you are done using the Face.
```

This means that there is no copying being done and the lifetime of the Face is constrained by the lifetime of the buffer passed in.  This is what this patch implements.  Faces loaded from a file are `'static`, while Faces loaded from a buffer have the lifetime of the buffer.

Without this patch, `freetype-rs` will gladly pass a pointer whose contents can get clobbered on the heap after deallocation.

I'm really sad to say that this bug cost me about 2 weeks of development :sob:.