### PR TITLE
Removed depreciated attribute.

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -91,7 +91,6 @@ impl Glyph {
         }
     }
 
-    #[deprecated = "use advance_x and advance_y instead"]
     pub fn advance(&self) -> ffi::FT_Vector {
         unsafe {
             (*self.raw).advance


### PR DESCRIPTION
Stability attributes can no longer be used in Rust. Removing this line to let the crate compile, although I'm not sure if there is a way to specify that this function is depreciated any longer. Perhaps we should just remove the function?