### PR TITLE
Require self to be mutable in face.raw_mut

### DIFF
--- a/src/face.rs
+++ b/src/face.rs
@@ -242,7 +242,7 @@ impl<'a> Face<'a> {
     }
 
     #[inline(always)]
-    pub fn raw_mut(&self) -> &mut ffi::FT_FaceRec {
+    pub fn raw_mut(&mut self) -> &mut ffi::FT_FaceRec {
         unsafe {
             &mut *self.raw
         }


### PR DESCRIPTION
It better reflects the real intentions: we want to operate with FT_Face
as mutable struct so Face should also be mutable.

Relates: #154