### PR TITLE
Bitmap: Use abs(pitch) * rows as the bitmap length

### DIFF
--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -66,7 +66,7 @@ impl Bitmap {
         unsafe {
             slice::from_raw_parts(
                 (*self.raw).buffer,
-                (self.width() * self.rows()) as usize
+                (self.pitch().abs() * self.rows()) as usize
             )
         }
     }


### PR DESCRIPTION
The current calculation (width * rows) assumes that one pixel equals one byte which is not the case when rendering in monochrome mode. This can cause the length of the resulting slice to either be too long (risking segfaults) or too short (causing panics or partial glyphs) when using the monochrome mode.

When in monochrome mode freetype renders one bit per pixel, padded to the nearest multiple of 2 bytes (http://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html#FT_Bitmap). For example a glyph with dimensions 1x5 pixels (width x height) will use 10 bytes with only the most significant bit in the first byte in each row corresponding to the glyph itself. The old calculation assumes that this glyph will use 5 bytes in monochrome mode.

A glyph with the dimensions 5x5 pixels also uses a buffer of 10 bytes, but currently it will receive a length of 25.

If the pitch is negative the buffer pointer is still pointing to the start of the allocated buffer and the length is the same as if it was a positive number of the same magnitude. The difference is that the start of the buffer points at the last row of the glyph (["On the opposite, if the pitch is negative, the first bytes of the pixel buffer are part of the lower bitmap row."](http://www.freetype.org/freetype2/docs/glyphs/glyphs-7.html)), rendering the glyph by stepping abs(pitch) forwards in the buffer will render the glyph upside down (["In all cases, the pitch is an offset to add to a bitmap pointer in order to go down one row."](http://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html#FT_Bitmap)).