### PR TITLE
Remove deprecated 'Glyph::advance'.

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -88,13 +88,6 @@ impl Glyph {
         }
     }
 
-    /// DEPRECATED: use advance_x and advance_y instead
-    pub fn advance(&self) -> ffi::FT_Vector {
-        unsafe {
-            (*self.raw).advance
-        }
-    }
-
     #[inline(always)]
     pub fn format(&self) -> ffi::FT_Glyph_Format {
         unsafe {


### PR DESCRIPTION
Closes #148 