### PR TITLE
to_owned used in favor of to_string in face.rs

### DIFF
--- a/src/face.rs
+++ b/src/face.rs
@@ -358,7 +358,7 @@ impl<'a> Face<'a> {
 
 impl<'a> fmt::Debug for Face<'a> {
     fn fmt(&self, form: &mut fmt::Formatter) -> fmt::Result {
-        let name = self.style_name().unwrap_or("[unknown name]".to_string());
+        let name = self.style_name().unwrap_or("[unknown name]".to_owned());
         try!(form.write_str("Font Face: "));
         form.write_str(&name[..])
     }


### PR DESCRIPTION
Hi guys,

I've had to use freetype-rs recently, and i've found a call of to_string(). This does allocate stuff. 

We should favor using to_owned() as allocation is not needed.

Thanks for looking into it.