### PR TITLE
Add support for LCD filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use error::{ FtResult, Error };
 pub use face::Face;
 pub use glyph::Glyph;
 pub use glyph_slot::GlyphSlot;
-pub use library::Library;
+pub use library::{ Library, LcdFilter };
 pub use outline::Outline;
 pub use render_mode::RenderMode;
 pub use freetype_sys as ffi;

--- a/src/library.rs
+++ b/src/library.rs
@@ -25,6 +25,15 @@ extern "C" fn realloc_library(_memory: ffi::FT_Memory,
     }
 }
 
+#[repr(u32)]
+#[derive(Copy, Clone)]
+pub enum LcdFilter {
+    LcdFilterNone    = ffi::FT_LCD_FILTER_NONE,
+    LcdFilterDefault = ffi::FT_LCD_FILTER_DEFAULT,
+    LcdFilterLight   = ffi::FT_LCD_FILTER_LIGHT,
+    LcdFilterLegacy  = ffi::FT_LCD_FILTER_LEGACY
+}
+
 static mut MEMORY: ffi::FT_MemoryRec = ffi::FT_MemoryRec {
     user: 0 as *mut c_void,
     alloc: alloc_library,
@@ -89,6 +98,17 @@ impl Library {
         };
         if err == ffi::FT_Err_Ok {
             Ok(unsafe { Face::from_raw(self.raw, face) })
+        } else {
+            Err(err.into())
+        }
+    }
+
+    pub fn set_lcd_filter(&self, lcd_filter: LcdFilter) -> FtResult<()> {
+        let err = unsafe {
+            ffi::FT_Library_SetLcdFilter(self.raw, lcd_filter as u32)
+        };
+        if err == ffi::FT_Err_Ok {
+            Ok(())
         } else {
             Err(err.into())
         }


### PR DESCRIPTION
Freetype is able to render glyphs at 3 times the width to exploit the subpixel layout on LCD monitors and increase the apparent horizontal resolution, at the expense of reduced color fidelity. This is achieved by loading a glyph with the `FT_LOAD_TARGET_LCD` flag. Unfortunately, this introduces severe color fringing. To remedy this, Freetype can apply a 1D FIR filter along the X-axis to such bitmaps, reducing color fringing considerably but with slightly blurrier results. The details are better explained [here](https://www.freetype.org/freetype2/docs/reference/ft2-lcd_filtering.html).  

This commit adds bindings for `FT_Library_SetLcdFilter` and the `LcdFilter` enum in order to expose this functionality.

I added the necessary method to the `Library` struct, and an enum inside the `library` module. That feels weird to me, as that functionality probably doesn't belong to the core `library` module, but the Freetype API makes it really clear that it operates on the `FT_Library`, and nothing beneath it. (It's prefixed with `FT_Library_`, and takes an `FT_Library` as the only parameter besides the actual LCD filter to set.) If you can think of a better place for it, I'd be happy to move it.