### PR TITLE
Allow font bytes to have multiple owners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@
 rusti.sh
 watch.sh
 /examples/**/target
+.vscode
 
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "freetype-rs"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 keywords = ["freetype", "font", "glyph"]
 description = "Bindings for FreeType font library"


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

The current architecture using borrows doesn't allow a font's bytes to have multiple owners, preventing use cases involving static lifetimes, and is thus needlessly restrictive. Switching to an Rc type resolves this problem.