### PR TITLE
Release FT_BitmapGlyph when BitmapGlyph is droped

### DIFF
--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -82,7 +82,7 @@ impl Glyph {
             ffi::FT_Glyph_To_Bitmap(&mut the_glyph, render_mode as u32, p_origin, 0)
         };
         if err == ffi::FT_Err_Ok {
-            Ok(unsafe { BitmapGlyph::from_raw(the_glyph as ffi::FT_BitmapGlyph) })
+            Ok(unsafe { BitmapGlyph::from_raw(self.library_raw, the_glyph as ffi::FT_BitmapGlyph) })
         } else {
             Err(err.into())
         }


### PR DESCRIPTION
Until now BitmapGlyph auto-derives Copy and Clone, while not actually taking care of the FT_BitmapGlyph lifetime. The glyph is never released and because of that leaks memory in the size of the bitmap.

This patch adapts the BitmapGlyph to have similar behavior as Glyph, by not supporting Copy, explicit implementation of Clone (by creating a copy of FT_BitmapGlyph) and releasing the FT_BitmapGlyph by implementing Drop.