### PR TITLE
Allow TrueTypeOS2Table::from_face on the BSDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "freetype-rs"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 keywords = ["freetype", "font", "glyph"]
 description = "Bindings for FreeType font library"
@@ -18,7 +18,7 @@ name = "freetype"
 
 bitflags = "1.0.0"
 libc = "0.2.1"
-freetype-sys = "0.7.0"
+freetype-sys = "0.7.1"
 
 [dev-dependencies]
 

--- a/src/tt_os2.rs
+++ b/src/tt_os2.rs
@@ -7,7 +7,6 @@ pub struct TrueTypeOS2Table {
 }
 
 impl TrueTypeOS2Table  {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub fn from_face(face: &mut Face) -> Option<Self> {
         unsafe {
             let os2 = ffi::FT_Get_Sfnt_Table(face.raw_mut() as *mut ffi::FT_FaceRec, ffi::ft_sfnt_os2) as ffi::TT_OS2_Internal;


### PR DESCRIPTION
freetype-sys `FT_Get_Sfnt_Table` works on the BSDs (see https://github.com/PistonDevelopers/freetype-sys/pull/75) therefore `TrueTypeOS2Table::from_face` should be allowed as well.

If freetype-sys is bumped to 0.7.1 I can add a commit changing `Cargo.toml` so freetype-rs can depend on that. Also it would be good if we can do a version bump for freetype-rs so the depency in https://github.com/jwilm/alacritty can be updated as well.