### PR TITLE
Expose TrueTypePostscriptTable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "freetype-rs"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Coeuvre <coeuvre@gmail.com>"]
 keywords = ["freetype", "font", "glyph"]
 description = "Bindings for FreeType font library"
@@ -18,7 +18,7 @@ name = "freetype"
 
 bitflags = "1.0.0"
 libc = "0.2.1"
-freetype-sys = "0.7.1"
+freetype-sys = "0.8.0"
 
 [dev-dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod outline;
 pub mod render_mode;
 pub mod stroker;
 pub mod tt_os2;
+pub mod tt_postscript;
 
 pub type BBox = ffi::FT_BBox;
 pub type GlyphMetrics = ffi::FT_Glyph_Metrics;

--- a/src/tt_postscript.rs
+++ b/src/tt_postscript.rs
@@ -1,0 +1,85 @@
+use ffi;
+use face::Face;
+
+#[derive(Copy, Clone)]
+pub struct TrueTypePostscriptTable {
+    raw: ffi::TT_Postscript_Internal
+}
+
+impl TrueTypePostscriptTable  {
+    pub fn from_face(face: &mut Face) -> Option<Self> {
+        unsafe {
+            let post = ffi::FT_Get_Sfnt_Table(face.raw_mut() as *mut ffi::FT_FaceRec, ffi::ft_sfnt_post) as ffi::TT_Postscript_Internal;
+            if !post.is_null() && (*post).formatType != 0 {
+                Some(TrueTypePostscriptTable {
+                    raw: post
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn format_type(&self) -> ffi::FT_Fixed {
+        unsafe {
+            (*self.raw).formatType
+        }
+    }
+
+    #[inline(always)]
+    pub fn italic_angle(&self) -> ffi::FT_Fixed {
+        unsafe {
+            (*self.raw).italicAngle
+        }
+    }
+
+    #[inline(always)]
+    pub fn underline_position(&self) -> ffi::FT_Short {
+        unsafe {
+            (*self.raw).underlinePosition
+        }
+    }
+
+    #[inline(always)]
+    pub fn underline_thickness(&self) -> ffi::FT_Short {
+        unsafe {
+            (*self.raw).underlineThickness
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_fixed_pitch(&self) -> ffi::FT_ULong {
+        unsafe {
+            (*self.raw).isFixedPitch
+        }
+    }
+
+    #[inline(always)]
+    pub fn min_mem_type_42(&self) -> ffi::FT_ULong {
+        unsafe {
+            (*self.raw).minMemType42
+        }
+    }
+
+    #[inline(always)]
+    pub fn max_mem_type_42(&self) -> ffi::FT_ULong {
+        unsafe {
+            (*self.raw).maxMemType42
+        }
+    }
+
+    #[inline(always)]
+    pub fn min_mem_type_1(&self) -> ffi::FT_ULong {
+        unsafe {
+            (*self.raw).minMemType1
+        }
+    }
+
+    #[inline(always)]
+    pub fn max_mem_type_1(&self) -> ffi::FT_ULong {
+        unsafe {
+            (*self.raw).maxMemType1
+        }
+    }
+}


### PR DESCRIPTION
This is a mechanical change that follows the pattern used to expose the
TrueTypeOS2Table.

This depends on PistonDevelopers/freetype-sys#77.