### PR TITLE
Fix Error::description deprication warning

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -204,7 +204,7 @@ impl From<i32> for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(error::Error::description(self))
+        f.write_str(&self.to_string())
     }
 }
 


### PR DESCRIPTION
I noticed this while testing a freetype-sys change for https://github.com/PistonDevelopers/freetype-sys/issues/91, so I thought I might as well send a quick PR.

This might increase the minimum supported Rust version, but I'm not sure if freetype-rs makes any guarantee in that regard..