### PR TITLE
Expose FT_FaceRec::num_glyphs

### DIFF
--- a/src/face.rs
+++ b/src/face.rs
@@ -321,6 +321,13 @@ impl Face {
         }
     }
 
+    #[inline(always)]
+    pub fn num_glyphs(&self) -> ffi::FT_Long {
+        unsafe {
+            (*self.raw).num_glyphs
+        }
+    }
+
     pub fn family_name(&self) -> Option<String> {
         let family_name = unsafe { (*self.raw).family_name };
 


### PR DESCRIPTION
The C library has a `num_glyphs` field that is useful when iterating over all the glyphs in a face.