### PR TITLE
Remove allocation requirement for Face

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::ffi::{ CString, OsStr };
 use std::ptr::null_mut;
 use std::rc::Rc;
@@ -111,6 +112,25 @@ impl Library {
 
         let err = unsafe {
             ffi::FT_New_Memory_Face(self.raw, buffer.as_ptr(), buffer.len() as ffi::FT_Long,
+                                    face_index as ffi::FT_Long, &mut face)
+        };
+        if err == ffi::FT_Err_Ok {
+            Ok(unsafe { Face::from_raw(self.raw, face, Some(buffer)) })
+        } else {
+            Err(err.into())
+        }
+    }
+
+    /// Similar to `new_face`, but loads file data from a byte array in memory
+    pub fn new_memory_face2<T>(&self, buffer: T, face_index: isize) -> FtResult<Face<T>>
+    where
+        T: Borrow<[u8]>
+    {
+        let mut face = null_mut();
+        let buf = buffer.borrow();
+
+        let err = unsafe {
+            ffi::FT_New_Memory_Face(self.raw, buf.as_ptr(), buf.len() as ffi::FT_Long,
                                     face_index as ffi::FT_Long, &mut face)
         };
         if err == ffi::FT_Err_Ok {


### PR DESCRIPTION
I'm using this in a embedded environment so having to allocate a `Rc<Vec<u8>>` when I already have a `&'static [u8]` available is wasteful.

I've added a `Library::new_memory_face2` (to avoid breaking changes) which would allow one to create a `Face` using a `&[u8]`, `Vec<u8>`, `[u8; N]`, `Box<[u8]>`, `Rc<[u8]>`, etc.

I would've made an issue first but this was a small enough change to simply express as a PR.