### PR TITLE
Add SDF to RenderMode

### DIFF
--- a/src/render_mode.rs
+++ b/src/render_mode.rs
@@ -8,5 +8,6 @@ pub enum RenderMode {
     Mono = ffi::FT_RENDER_MODE_MONO,
     Lcd = ffi::FT_RENDER_MODE_LCD,
     LcdV = ffi::FT_RENDER_MODE_LCD_V,
+    Sdf = ffi::FT_RENDER_MODE_SDF,
     Max = ffi::FT_RENDER_MODE_MAX,
 }


### PR DESCRIPTION
Adds the `Sdf` variant to `RenderMode`, making it possible to render glyphs as SDFs.

This depends on a version of `freetype-sys` with [#118](https://github.com/PistonDevelopers/freetype-sys/pull/118) to be published.