### PR TITLE
feat: charmap api

### DIFF
--- a/src/charmap.rs
+++ b/src/charmap.rs
@@ -1,0 +1,27 @@
+use freetype_sys::FT_CharMap;
+
+pub struct CharMap {
+    raw: FT_CharMap,
+}
+
+impl CharMap {
+    pub fn new(raw: FT_CharMap) -> Self {
+        CharMap { raw }
+    }
+
+    pub fn platform_id(&self) -> u16 {
+        unsafe { (*self.raw).platform_id }
+    }
+
+    pub fn encoding_id(&self) -> u16 {
+        unsafe { (*self.raw).encoding_id }
+    }
+
+    pub fn encoding(&self) -> u32 {
+        unsafe { (*self.raw).encoding }
+    }
+
+    pub fn raw(&self) -> FT_CharMap {
+        self.raw
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub use stroker::{Stroker, StrokerLineCap, StrokerLineJoin};
 
 pub mod bitmap;
 pub mod bitmap_glyph;
+pub mod charmap;
 pub mod error;
 pub mod face;
 pub mod glyph;


### PR DESCRIPTION
`get_char_index` and `get_name_index` will all return None if result is 0 , freetype return 0 if query result not exist, i think return  None is may be better than error.