### PR TITLE
Fixed empty contour wrong if branch

### DIFF
--- a/src/outline.rs
+++ b/src/outline.rs
@@ -34,6 +34,10 @@ impl<'a> Outline<'a> {
     pub fn contours_iter(&self) -> ContourIterator<'a> {
         unsafe { ContourIterator::from_raw(self.raw) }
     }
+
+    pub fn flags(&self) -> i32 {
+        i32::from(self.raw.flags)
+    }
 }
 
 const TAG_ONCURVE: c_char = 0x01;

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -142,7 +142,7 @@ impl<'a> Iterator for ContourIterator<'a> {
     type Item = CurveIterator<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.contour_end_idx > self.last_end_idx {
+        if self.contour_end_idx.is_null() || self.contour_end_idx > self.last_end_idx {
             None
         } else {
             unsafe {


### PR DESCRIPTION
When no contours exist for an outline and a `CurveIterator` is made, iterating it will cause the if check to fail, attempting to return `Some(CurveIterator)` rather than returning `None` as it should. Adding a null check avoids a segfault.