### PR TITLE
Library: Add Send/Sync

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -164,6 +164,9 @@ impl Library {
     }
 }
 
+unsafe impl Send for Library {}
+unsafe impl Sync for Library {}
+
 impl Drop for Library {
     fn drop(&mut self) {
         let err = unsafe { ffi::FT_Done_Library(self.raw) };


### PR DESCRIPTION
According to the FAQ [1] the freetype library is thread-safe.  This change adds the Send and Sync traits to ft::Library to reflect this and remove the unnecessary restriction. The most important of these being Sync, right now you cannot move any object holding the freetype Library struct into a different thread.

[1] https://freetype.org/freetype2/docs/ft2faq.html